### PR TITLE
Session Timeout: Add new SignInUrl property for Session Timeout plugin

### DIFF
--- a/Components.Tests/RenderTests/RenderTests.cs
+++ b/Components.Tests/RenderTests/RenderTests.cs
@@ -113,6 +113,24 @@ namespace GoC.WebTemplate.Components.Test.RenderTests
         }
 
         [Theory, AutoNSubstituteData]
+        public void RenderSessionTimeoutControlTextOverrides(Model sut)
+        {
+            sut.Settings.SessionTimeout.Enabled = true;
+            sut.Settings.SessionTimeout.RefreshOnClick = true;
+            sut.Settings.SessionTimeout.TextOverrides = new WebTemplate.Entities.Source.SessionTimeoutTextOverrides
+            {
+                ButtonContinue = "Continue Button",
+                ButtonEnd = "End Button",
+                ButtonSignIn = "Sign In Button",
+                TimeoutAlready = "Timeout Already",
+                TimeoutEnd = "Timeout End"
+            };
+            var result = sut.Render.SessionTimeoutControl();
+            result.ToString().Should().ContainAll("class='wb-sessto'", "inactivity", "reactionTime", "sessionalive", "logouturl", "refreshCallbackUrl", "refreshOnClick", "refreshLimit", "method", "additionalData", "textOverrides", "buttonContinue", "buttonEnd", "buttonSignin", "timeoutAlready", "timeoutEnd");
+        }
+
+
+        [Theory, AutoNSubstituteData]
         public void RenderSessionRefreshRendersDefaultValue(Model sut)
         {
             sut.Settings.SessionTimeout.RefreshOnClick = default;

--- a/Entities/Source/SessionTimeout.cs
+++ b/Entities/Source/SessionTimeout.cs
@@ -59,5 +59,11 @@ namespace GoC.WebTemplate.Components.Entities
         /// Additional data to send with the request.
         /// </summary>
         public string AdditionalData { get; set; }
+
+        /// <summary>
+        /// URL used for the Sign In action once the session has expired.
+        /// </summary>
+        [JsonProperty(PropertyName = "signInUrl")]
+        public string SignInUrl { get; set; }
     }
 }

--- a/Entities/Source/SessionTimeout.cs
+++ b/Entities/Source/SessionTimeout.cs
@@ -1,3 +1,5 @@
+using GoC.WebTemplate.Entities.Source;
+
 using Newtonsoft.Json;
 
 namespace GoC.WebTemplate.Components.Entities
@@ -65,5 +67,11 @@ namespace GoC.WebTemplate.Components.Entities
         /// </summary>
         [JsonProperty(PropertyName = "signInUrl")]
         public string SignInUrl { get; set; }
+
+        /// <summary>
+        /// Optional button text and message elements to override the defaults.
+        /// </summary>
+        [JsonProperty(PropertyName = "textOverrides")]
+        public SessionTimeoutTextOverrides TextOverrides { get; set; }
     }
 }

--- a/Entities/Source/SessionTimeoutTextOverrides.cs
+++ b/Entities/Source/SessionTimeoutTextOverrides.cs
@@ -1,0 +1,43 @@
+﻿using Newtonsoft.Json;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GoC.WebTemplate.Entities.Source
+{
+    public class SessionTimeoutTextOverrides
+    {
+        /// <summary>
+        /// Text for the Continue Session button.
+        /// </summary>
+        [JsonProperty(PropertyName = "buttonContinue")]
+        public string ButtonContinue { get; set; }
+
+        /// <summary>
+        /// Text for the End Session button.
+        /// </summary>
+        [JsonProperty(PropertyName = "buttonEnd")]
+        public string ButtonEnd { get; set; }
+
+        /// <summary>
+        /// Text for the Sign In button
+        /// </summary>
+        [JsonProperty(PropertyName = "buttonSignin")]
+        public string ButtonSignIn { get; set; }
+
+        /// <summary>
+        /// Text for the message displayed below the timer.
+        /// </summary>
+        [JsonProperty(PropertyName = "timeoutEnd")]
+        public string TimeoutEnd { get; set; }
+
+        /// <summary>
+        /// Text for the message displayed when the session has expired.
+        /// </summary>
+        [JsonProperty(PropertyName = "timeoutAlready")]
+        public string TimeoutAlready { get; set; }
+    }
+}

--- a/MVC/WebTemplateMVC.xsd
+++ b/MVC/WebTemplateMVC.xsd
@@ -31,6 +31,7 @@
               </xs:simpleType>
             </xs:attribute>
             <xs:attribute name="logoutUrl" type="xs:string" use="required" />
+            <xs:attribute name="signInUrl" type="xs:string" use="optional" />
             <xs:attribute name="refreshCallBackUrl" type="xs:string" use="optional" />
             <xs:attribute name="refreshOnClick" type="xs:boolean" use="optional" />
             <xs:attribute name="refreshLimit" type="xs:positiveInteger" use="optional" />

--- a/WebForms/WebTemplateWebForms.xsd
+++ b/WebForms/WebTemplateWebForms.xsd
@@ -31,6 +31,7 @@
               </xs:simpleType>
             </xs:attribute>
             <xs:attribute name="logoutUrl" type="xs:string" use="required" />
+            <xs:attribute name="signInUrl" type="xs:string" use="optional" />
             <xs:attribute name="refreshCallBackUrl" type="xs:string" use="optional" />
             <xs:attribute name="refreshOnClick" type="xs:boolean" use="optional" />
             <xs:attribute name="refreshLimit" type="xs:positiveInteger" use="optional" />


### PR DESCRIPTION
Session Timeout: Add the new SignInUrl property for the Session Timeout plugin in Wet-Boew release v4.0.82.
Add text override configuration to Session Timeout plugin in Wet-Boew release v4.0.84.  Add Render test for text overrides.
Closes issue #111 